### PR TITLE
Rematch Button

### DIFF
--- a/Scripts/JarUIManager.cs
+++ b/Scripts/JarUIManager.cs
@@ -143,8 +143,9 @@ public partial class JarUIManager : Node
 
 		if (IsMultiplayer && jarMan.HasWonEnoughRounds)
 		{
-			nextButton.Visible = false;
-			quitButton.GrabFocus();
+			nextButton.Text = "REMATCH";
+			nextButton.Visible = true;
+			nextButton.GrabFocus();
 		}
 		else
 		{


### PR DESCRIPTION
Adds a REMATCH option after a player wins a multiplayer series.

The button reuses the existing ReplayLevel flow, preserving the selected player count, music, speed, gameplay settings, and other match options. It resets the series win count and gives REMATCH default focus. Great for quickly trouncing your friends again!

Tested with Godot 4.7 .NET on macOS.